### PR TITLE
Fix 0.1.6/production/backend 66

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+src/main/resources/application-test.yml
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -25,12 +25,13 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.projectlombok:lombok'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -39,6 +40,10 @@ dependencies {
     implementation 'io.confluent:kafka-avro-serializer:7.4.0'
 
 
+}
+
+compileJava {
+    dependsOn generateAvroJava
 }
 
 tasks.named('test') {

--- a/src/main/java/windeath44/orchestration/Application.java
+++ b/src/main/java/windeath44/orchestration/Application.java
@@ -2,13 +2,12 @@ package windeath44.orchestration;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.kafka.annotation.EnableKafka;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = HibernateJpaAutoConfiguration.class)
 @ConfigurationPropertiesScan
-@EnableJpaAuditing
 @EnableKafka
 public class Application {
   public static void main(String[] args) {

--- a/src/main/java/windeath44/orchestration/domain/mapper/EventMapper.java
+++ b/src/main/java/windeath44/orchestration/domain/mapper/EventMapper.java
@@ -51,7 +51,7 @@ public class EventMapper {
   }
 
   public MemorialApplicationEvent memorialApplicationCompensateEvent(MemorialApplicationAvroSchema memorialAvroSchema) {
-    String aggregateId = "memorial-application-" + memorialApplicationAvroSchema.getMemorialApplicationId();
+    String aggregateId = "memorial-application-" + memorialAvroSchema.getMemorialApplicationId();
     String aggregateType = "MEMORIAL_APPLICATION";
     EventType eventType = EventType.MEMORIAL_APPLICATION_CANCELLED;
 
@@ -59,7 +59,7 @@ public class EventMapper {
             .aggregateId(aggregateId)
             .aggregateType(aggregateType)
             .eventType(eventType)
-            .eventData(memorialApplicationAvroSchema)
+            .eventData(memorialAvroSchema)
             .build();
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,11 +3,15 @@ spring:
     name : windeath44.server.orchestration
   data:
     mongodb:
-      uri: mongodb://localhost:27017/
+      uri: mongodb://${MONGODB_URL}
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 
 kafka:
-  bootstrap-servers: ${KAFKA_SERVER}
-  schema-registry-url: http://localhost:8081
+  bootstrap-servers: ${KAFKA_URL}
+  schema-registry-url: ${SCHEMA_REGISTRY_URL}
   consumer:
     auto-offset-reset: earliest
     key-deserializer: org.apache.kafka.common.serialization.StringDeserializer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 테스트용 애플리케이션 설정 파일이 버전 관리에서 제외되었습니다.
  * Java 버전이 21에서 17로 변경되었습니다.
  * 일부 Gradle 의존성이 추가, 제거 및 재배치되었습니다.
  * Gradle 빌드 시 Avro 코드 생성이 Java 컴파일 이전에 실행되도록 변경되었습니다.

* **Bug Fixes**
  * 환경 변수 기반으로 MongoDB, Kafka, Schema Registry 설정이 적용되어 배포 환경에 따라 유연하게 설정할 수 있습니다.

* **Refactor**
  * JPA 관련 자동 설정이 비활성화되었으며, 관련 어노테이션 및 설정이 수정되었습니다.
  * 일부 메서드의 파라미터 이름이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->